### PR TITLE
Make test workflow

### DIFF
--- a/.github/workflows/reject-collab-approvers.yml
+++ b/.github/workflows/reject-collab-approvers.yml
@@ -1,0 +1,18 @@
+name: Dismiss code reviews from collaborators
+
+on:
+  pull_request_target:
+    branches:
+      - master
+      - main
+      - develop
+
+
+jobs:
+  approver-vibe-check:
+    name: Dismiss code reviews from collaborators
+    runs-on: ubuntu-latest
+    if: github.event.review.state == 'approved'
+    steps:
+      - name: Dismiss code reviews from collaborators
+        uses: ./

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Conditionally approve the PR if all commits were made by trusted committers'
-description: 'Approve GitHub pull request if all commits in the PR were made by users on a configurable whitelist of trusted committers.'
+name: 'Dismiss code reviews from collaborators'
+description: 'Dismiss code reviews on pull requests from anyone worked on it.'
 branding:
   icon: 'thumbs-down'
   color: 'red'
@@ -8,6 +8,7 @@ inputs:
   github-token:
     description: 'The GITHUB_TOKEN secret or PAT'
     required: true
+    default: '${{ secrets.GITHUB_TOKEN }}'
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR adds a test workflow that runs locally, plus updates the `action.yml` file to have an accurate description.  I also added that `GITHUB_TOKEN` should be the default, so you don't _have_ to specify it if it isn't needed.